### PR TITLE
add: errors handlers

### DIFF
--- a/be/Gemfile
+++ b/be/Gemfile
@@ -52,3 +52,4 @@ end
 gem 'config'
 gem 'dotenv-rails'
 gem 'jwt'
+gem 'rails-i18n'

--- a/be/Gemfile.lock
+++ b/be/Gemfile.lock
@@ -178,6 +178,9 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
+    rails-i18n (7.0.9)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.1.3.2)
       actionpack (= 7.1.3.2)
       activesupport (= 7.1.3.2)
@@ -256,6 +259,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rack-cors
   rails (~> 7.1.3, >= 7.1.3.2)
+  rails-i18n
   rubocop
   rubocop-performance
   rubocop-rails

--- a/be/app/controllers/api/v1/admins_controller.rb
+++ b/be/app/controllers/api/v1/admins_controller.rb
@@ -1,19 +1,15 @@
 class Api::V1::AdminsController < ApplicationController
   def create
     admin = Admin.new(admin_params)
-    if admin.save
-      render json: {
-        status: 'success',
+    admin.save!
+    render json: {
+      success: true,
+      data: {
         email: admin.email,
         name: admin.name
-      }, status: :ok
-    else
-      render json: {
-        status: 'error',
-        message: 'Signup failed!',
-        errors: admin.errors
-      }, status: :unprocessable_entity    
-    end
+      }
+    }, status: :ok
+
   end
 
   private

--- a/be/app/controllers/application_controller.rb
+++ b/be/app/controllers/application_controller.rb
@@ -1,3 +1,13 @@
 class ApplicationController < ActionController::API
   include ActionController::Cookies
+  include Api::V1::RescueExceptions
+  before_action :set_locale
+
+  private
+
+  def set_locale
+    # if params[:locale] is nil then I18n.default_locale will be used
+    I18n.locale = params[:locale] || I18n.default_locale
+    # I18n.locale = I18n.default_locale unless I18n.available_locales.include?(I18n.locale.to_sym)
+  end
 end

--- a/be/app/controllers/concerns/api/v1/rescue_exceptions.rb
+++ b/be/app/controllers/concerns/api/v1/rescue_exceptions.rb
@@ -1,0 +1,26 @@
+module Api
+  module V1
+    module RescueExceptions
+      extend ActiveSupport::Concern
+      included do
+        rescue_from ActiveRecord::RecordInvalid, with: :render_unprocessable_entity_response
+        rescue_from ActiveRecord::RecordNotFound, with: :render_record_not_found_response
+        rescue_from Errors::Api::Unauthenticated, with: :render_unauthenticated_response
+
+        protected
+
+        def render_unprocessable_entity_response(error, status: :unprocessable_entity)
+          render json: Errors::ActiveRecord::Validation.new(error.record).to_hash, status:
+        end
+
+        def render_record_not_found_response(error, status: :not_found)
+          render json: Errors::ActiveRecord::NotFound.new(error).to_hash, status:
+        end
+
+        def render_unauthenticated_response(error, status: :unauthorized)
+          render json: error.to_hash, status:
+        end
+      end
+    end
+  end
+end

--- a/be/config/application.rb
+++ b/be/config/application.rb
@@ -29,5 +29,9 @@ module Be
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
     config.middleware.use ActionDispatch::Cookies
+    config.eager_load_paths << Rails.root.join('lib')
+    config.i18n.load_path += Dir[Rails.root.join('config/locales/**/*.{rb,yml}')]
+    config.i18n.available_locales = [:en, :ja]
+    config.i18n.default_locale = :en
   end
 end

--- a/be/config/locales/en/errors.yml
+++ b/be/config/locales/en/errors.yml
@@ -1,0 +1,38 @@
+en:
+  errors:
+    resources:
+      user: user
+      admin: admin
+    messages:
+      not_found: "not found"
+      bad_request: "missing params"
+      unauthenticated: "email or password is incorrect"
+      invalid_token: "invalid token or token expired"
+    codes:
+      invalid_token: 997
+      unauthenticated: 998
+      bad_request: 999
+      default: 1000
+      confirmation: 1001
+      accepted: 1002
+      blank: 1003
+      present: 1004
+      too_short: 1005
+      too_long: 1006
+      wrong_length: 1007
+      taken: 1008
+      invalid: 1009
+      inclusion: 1010
+      exclusion: 1011
+      required: 1012
+      not_a_number: 1013
+      greater_than: 1014
+      greater_than_or_equal_to: 1015
+      equal_to: 1016
+      less_than: 1017
+      less_than_or_equal_to: 1018
+      other_than: 1019
+      not_an_integer: 1020
+      odd: 1021
+      even: 1022
+      record_not_found: 1100

--- a/be/config/locales/ja/errors.yml
+++ b/be/config/locales/ja/errors.yml
@@ -1,0 +1,38 @@
+ja:
+  errors:
+    resources:
+      user: ユーザー
+      admin: 管理
+    messages:
+      not_found: "見つかれませんでした。"
+      bad_request: "無効なリクエストでした。"
+      unauthenticated: "メール又はパスワードに誤りがありますあります。もう一度入力してください。"
+      invalid_token: "無効なトーケン又は期限が満了しました。"
+    codes:
+      invalid_token: 997
+      unauthenticated: 998
+      bad_request: 999
+      default: 1000
+      confirmation: 1001
+      accepted: 1002
+      blank: 1003
+      present: 1004
+      too_short: 1005
+      too_long: 1006
+      wrong_length: 1007
+      taken: 1008
+      invalid: 1009
+      inclusion: 1010
+      exclusion: 1011
+      required: 1012
+      not_a_number: 1013
+      greater_than: 1014
+      greater_than_or_equal_to: 1015
+      equal_to: 1016
+      less_than: 1017
+      less_than_or_equal_to: 1018
+      other_than: 1019
+      not_an_integer: 1020
+      odd: 1021
+      even: 1022
+      record_not_found: 1100

--- a/be/lib/errors/active_record/not_found.rb
+++ b/be/lib/errors/active_record/not_found.rb
@@ -1,0 +1,25 @@
+module Errors
+  module ActiveRecord
+    class NotFound < Errors::BaseError
+      attr_reader :resource, :field, :detail
+
+      def initialize(error)
+        super
+        @resource = error.model.underscore
+        @field = error.primary_key
+        @detail = error.class.to_s.split('::')[1].underscore
+      end
+
+      def serialize_errors
+        [
+          {
+            resource: I18n.t(resource, scope: [:errors, :resources], default: resource.to_s),
+            field:,
+            code: I18n.t(detail, scope: [:errors, :codes]),
+            message: I18n.t('errors.messages.not_found')
+          }
+        ]
+      end
+    end
+  end
+end

--- a/be/lib/errors/active_record/validation.rb
+++ b/be/lib/errors/active_record/validation.rb
@@ -1,0 +1,46 @@
+module Errors
+  module ActiveRecord
+    class Validation < Errors::BaseError
+      attr_reader :record
+
+      def initialize(record)
+        super
+        @record = record
+      end
+
+      def serialize_errors(full_messages: true)
+        return unless record
+
+        messages = record.errors.to_hash(full_messages)
+        record.errors.details.map do |field, details|
+          detail = details.first[:error]
+          message = messages[field].first
+          {
+            resource: translate_resource,
+            field: translate_field(field),
+            code: translate_code(detail),
+            message:
+          }
+        end
+      end
+
+      def translate_resource
+        I18n.t(
+          @record.class.to_s.underscore, scope: [:errors, :resources], default: @record.class.to_s
+        )
+      end
+
+      def translate_field(field)
+        I18n.t(
+          field, scope: [:errors, :resources], default: field.to_s
+        )
+      end
+
+      def translate_code(detail)
+        I18n.t(
+          detail, scope: [:errors, :codes], default: detail.to_s
+        )
+      end
+    end
+  end
+end

--- a/be/lib/errors/api/unauthenticated.rb
+++ b/be/lib/errors/api/unauthenticated.rb
@@ -1,0 +1,9 @@
+module Errors
+  module Api
+    class Unauthenticated < Errors::BaseError
+      def initialize(code:, message:)
+        super(code:, message:)
+      end
+    end
+  end
+end

--- a/be/lib/errors/base_error.rb
+++ b/be/lib/errors/base_error.rb
@@ -1,0 +1,24 @@
+module Errors
+  class BaseError < StandardError
+    attr_reader :code, :message
+
+    def initialize(code: nil, message: nil)
+      super
+      @message = message
+      @code = code
+    end
+
+    def serialize_errors
+      [
+        {code:, message:}
+      ]
+    end
+
+    def to_hash
+      {
+        success: false,
+        errors: serialize_errors
+      }
+    end
+  end
+end

--- a/be/lib/errors/execution_error.rb
+++ b/be/lib/errors/execution_error.rb
@@ -1,0 +1,5 @@
+module Errors
+  class ExecutionError < Errors::BaseError
+
+  end
+end


### PR DESCRIPTION
## Linked Issues:  
- https://github.com/bs90/ep8_travel/issues/16
## 変更の概要
- エラーハンドリングを追加

## 具体的な実装内容
### やったこと
- ControllerでHappy pathのみ処理して、エラーが投げられる。
- Application_controllerで全てのExceptionsを処理
- エラーのI18nを定義 
### やらなかったこと

## 他の機能への影響
- なし
## 自動テストカバレッジ範囲
- なし
## レビュー前に読んでほしい参考資料
https://viblo.asia/p/error-handling-in-rails-api-the-rails-way-RQqKLvRrl7z
https://blog.rebased.pl/2016/11/07/api-error-handling.html
## 実装できなかった内容
- なし
## その他